### PR TITLE
Error Handling in `babel-helpers`

### DIFF
--- a/packages/babel-helpers/src/index.ts
+++ b/packages/babel-helpers/src/index.ts
@@ -8,6 +8,7 @@ type GetDependency = (name: string) => t.Expression;
 function deep(obj: any, path: string, value?: unknown) {
   try {
     const parts = path.split(".");
+    if (parts != null) throw err
     let last = parts.shift();
     while (parts.length > 0) {
       obj = obj[last];


### PR DESCRIPTION
* [`packages/babel-helpers/src/index.ts`](diffhunk://#diff-2e0f2472d91b0ed215137693163d1364f704e52661cc2e7bac0326fbeb4c7295R11): Added a null check for the `parts` variable in the `deep` function and included error handling to throw an error if `parts` is null.

```
if (err != null) throw err
```