### PR TITLE
Create sample.min.js

### DIFF
--- a/.github/workflows/codeql-monorepo-full.yml
+++ b/.github/workflows/codeql-monorepo-full.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Scan whole repo, split up by project
         id: whole-repo
-        uses: advanced-security/monorepo-code-scanning-action/whole-repo@main
+        uses: advanced-security/monorepo-code-scanning-action/whole-repo@paths-ignore
         with:
           projects-json: monorepo-projects.json
           queries: security-extended

--- a/.github/workflows/codeql-monorepo.yml
+++ b/.github/workflows/codeql-monorepo.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Spot changes to projects
         id: changes
-        uses: advanced-security/monorepo-code-scanning-action/changes@main
+        uses: advanced-security/monorepo-code-scanning-action/changes@paths-ignore
         with:
           projects-json: monorepo-projects.json
           queries: security-extended

--- a/.github/workflows/codeql-monorepo.yml
+++ b/.github/workflows/codeql-monorepo.yml
@@ -70,8 +70,8 @@ jobs:
 
       - name: Spot changes to projects
         id: changes
-        uses: advanced-security/monorepo-code-scanning-action/changes@main
-        #uses: advanced-security/monorepo-code-scanning-action/changes@paths-ignore
+        #uses: advanced-security/monorepo-code-scanning-action/changes@main
+        uses: advanced-security/monorepo-code-scanning-action/changes@paths-ignore
         with:
           projects-json: monorepo-projects.json
           queries: security-extended

--- a/.github/workflows/codeql-monorepo.yml
+++ b/.github/workflows/codeql-monorepo.yml
@@ -70,7 +70,8 @@ jobs:
 
       - name: Spot changes to projects
         id: changes
-        uses: advanced-security/monorepo-code-scanning-action/changes@paths-ignore
+        uses: advanced-security/monorepo-code-scanning-action/changes@main
+        #uses: advanced-security/monorepo-code-scanning-action/changes@paths-ignore
         with:
           projects-json: monorepo-projects.json
           queries: security-extended

--- a/packages/babel-cli/src/babel/sample.min.js
+++ b/packages/babel-cli/src/babel/sample.min.js
@@ -1,0 +1,1 @@
+console.writeline("hello, world!")

--- a/packages/babel-cli/src/babel/sample.min.js
+++ b/packages/babel-cli/src/babel/sample.min.js
@@ -1,1 +1,8 @@
 console.writeline("hello, world!")
+
+function insecurePassword(): string {
+  // BAD: the random suffix is not cryptographically secure
+  const suffix = Math.random();
+  const password = "myPassword" + suffix;
+  return password;
+}


### PR DESCRIPTION
add a min.js sample

- testing for: https://github.com/advanced-security/monorepo-code-scanning-action/pull/41

## Test 1 - Does not show extracting file  (but file count stays the same oddly)

Initial test (commit [[3a64cda](https://github.com/advanced-security/sample-javascript-monorepo/pull/15/commits/3a64cdad7f81f71b311df51899d5b5430925cfe7)](https://github.com/advanced-security/sample-javascript-monorepo/pull/15/commits/3a64cdad7f81f71b311df51899d5b5430925cfe7)):
- [Ignored the default CodeQL behavior](https://github.com/github/codeql/blob/877118fb3b4c6ad2cdd1bef79e31cf731312ec0b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java#L413-L415) and is extracting `.min.js` file:
```
  [2025-04-11 14:37:52] [build-stdout] Extracting /home/runner/work/sample-javascript-monorepo/sample-javascript-monorepo/packages/babel-cli/test/batch-test-runner/2.js
  [2025-04-11 14:37:52] [build-stdout] Done extracting /home/runner/work/sample-javascript-monorepo/sample-javascript-monorepo/packages/babel-cli/src/babel/sample.min.js (3 ms)
  [2025-04-11 14:37:52] [build-stdout] Extracting /home/runner/work/sample-javascript-monorepo/sample-javascript-monorepo/packages/babel-cli/test/batch-test-runner/3.js
 
 
 CodeQL scanned 252 out of 252 JavaScript files and 7 out of 7 TypeScript files in this invocation. Check the status page for overall coverage information: https://github.com/advanced-security/sample-javascript-monorepo/security/code-scanning/tools/CodeQL/status/

```

Fix test ( commit [d34ee8a](https://github.com/advanced-security/sample-javascript-monorepo/pull/15/commits/d34ee8a4630e8a213a83640b6222868475058676)):

- hmm same number of files extracted , but it clearly did NOT extract the .min.js file this time.

```
  [2025-04-14 22:28:39] [build-stdout] Extracting /home/runner/work/sample-javascript-monorepo/sample-javascript-monorepo/packages/babel-cli/test/batch-test-runner/2.js
  [2025-04-14 22:28:39] [build-stdout] Done extracting /home/runner/work/sample-javascript-monorepo/sample-javascript-monorepo/packages/babel-cli/test/fixtures/babel/stdin --out-file/options.json (6 ms)
  [2025-04-14 22:28:39] [build-stdout] Extracting /home/runner/work/sample-javascript-monorepo/sample-javascript-monorepo/packages/babel-cli/test/batch-test-runner/3.js
  [2025-04-14 22:28:39] [build-stdout] Done extracting /home/runner/work/sample-javascript-monorepo/sample-javascript-monorepo/packages/babel-cli/test/batch-test-runner/2.js (2 ms)

CodeQL scanned 252 out of 252 JavaScript files and 7 out of 7 TypeScript files in this invocation. Check the status page for overall coverage information: https://github.com/advanced-security/sample-javascript-monorepo/security/code-scanning/tools/CodeQL/status/
```


## Test 2 

- Added vuln with commit [b6632c](https://github.com/advanced-security/sample-javascript-monorepo/pull/15/commits/b6632c03bb51f19a437b7dd25e33d8630383f551)
  - https://github.com/advanced-security/sample-javascript-monorepo/security/code-scanning/19
  - shows as "generated"

![image](https://github.com/user-attachments/assets/8e38c318-b7fe-4d0f-a329-1ece469884e8)


- [25511e4](https://github.com/advanced-security/sample-javascript-monorepo/pull/15/commits/25511e432ddb6485bf6b65190ae43dbad01a20d1) commit switches to new branch that adds path ignore, closes [alert #19](https://github.com/advanced-security/sample-javascript-monorepo/security/code-scanning/19)!

![image](https://github.com/user-attachments/assets/e14c56eb-8cef-4d6c-b634-d784befd9d07)
![image](https://github.com/user-attachments/assets/5655a23d-8bf5-4e13-a031-042cff43c255)
